### PR TITLE
fix(prettier-config): public pkg

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -8,10 +8,12 @@
     "url": "git+https://github.com/salute-developers/grail.git"
   },
   "author": "Salute Frontend Team <salute.developers@gmail.com>",
-  "license": "UNLICENSED",
   "homepage": "https://github.com/salute-developers/grail/tree/master/packages/prettier-config",
   "peerDependencies": {
     "prettier": ">= 2.0.5",
     "typescript": ">= 3.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config-base@0.2.1-canary.1.2434917060.0
  npm install @salutejs/eslint-config@0.4.1-canary.1.2434917060.0
  npm install @salutejs/prettier-config@0.2.1-canary.1.2434917060.0
  npm install @salutejs/stylelint-config@0.3.1-canary.1.2434917060.0
  # or 
  yarn add @salutejs/eslint-config-base@0.2.1-canary.1.2434917060.0
  yarn add @salutejs/eslint-config@0.4.1-canary.1.2434917060.0
  yarn add @salutejs/prettier-config@0.2.1-canary.1.2434917060.0
  yarn add @salutejs/stylelint-config@0.3.1-canary.1.2434917060.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
