### PR TITLE
feat(eslint-config-base): add prettier config to eslint

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -1,3 +1,5 @@
+const prettierConfig = require('@salutejs/prettier-config');
+
 module.exports = {
     extends: [
         'airbnb-base',
@@ -51,7 +53,6 @@ module.exports = {
         'no-param-reassign': 'off',
         'no-shadow': 'warn',
         'consistent-return': 'off',
-        'prettier/prettier': 'error',
 
         '@typescript-eslint/explicit-function-return-type': 'off',
 
@@ -68,6 +69,10 @@ module.exports = {
         'import/no-extraneous-dependencies': ['off'],
         'arrow-body-style': 'off',
         'no-unused-expressions': 'off',
+        'prettier/prettier': [
+            'error',
+            prettierConfig,
+        ],
     },
     overrides: [
         {

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -10,6 +10,7 @@
   "author": "Salute Frontend Team <salute.developers@gmail.com>",
   "homepage": "https://github.com/salute-developers/grail/tree/master/packages/eslint-config-base",
   "peerDependencies": {
+    "@salutejs/prettier-config": "0.3.0",
     "@typescript-eslint/eslint-plugin": ">= 2.29.0",
     "@typescript-eslint/parser": ">= 2.29.0",
     "babel-eslint": ">= 10.1.0",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config-base@0.4.0-canary.2.2495979262.0
  npm install @salutejs/eslint-config@0.6.0-canary.2.2495979262.0
  # or 
  yarn add @salutejs/eslint-config-base@0.4.0-canary.2.2495979262.0
  yarn add @salutejs/eslint-config@0.6.0-canary.2.2495979262.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
