### PR TITLE
fix(stylelint-config): bump version

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salutejs/stylelint-config",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Salute stylelint config",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config@0.6.1-canary.6.3427694651.0
  npm install @salutejs/stylelint-config@0.5.1-canary.6.3427694651.0
  # or 
  yarn add @salutejs/eslint-config@0.6.1-canary.6.3427694651.0
  yarn add @salutejs/stylelint-config@0.5.1-canary.6.3427694651.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
