### PR TITLE
feat(eslint-config): restrict ton of logic inside useEffect callback

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -23,6 +23,13 @@ module.exports = {
         'jsx-a11y/no-static-element-interactions': 'off',
         'jsx-a11y/click-events-have-key-events': 'off',
         'jsx-a11y/no-noninteractive-tabindex': 'off',
+        'no-restricted-syntax': [
+            'error',
+            {
+                selector: "CallExpression[callee.name='useEffect'][arguments.0.body.body.length>10]",
+                message: 'go to read clean code',
+            },
+        ],
     },
     overrides: [
         {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config@0.8.0-canary.8.3697718396.0
  # or 
  yarn add @salutejs/eslint-config@0.8.0-canary.8.3697718396.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
