### PR TITLE
fix(stylelint-config): add missed plugin to plugins config

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-    plugins: ['stylelint-scss', 'stylelint-order'],
+    plugins: ['stylelint-scss', 'stylelint-order', 'stylelint-high-performance-animation'],
     processors: [
         [
             'stylelint-processor-styled-components',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config@0.7.1-canary.11.3985830807.0
  npm install @salutejs/stylelint-config@0.6.1-canary.11.3985830807.0
  # or 
  yarn add @salutejs/eslint-config@0.7.1-canary.11.3985830807.0
  yarn add @salutejs/stylelint-config@0.6.1-canary.11.3985830807.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
