### PR TITLE
fix(eslint-config): changed the autofix option for jsx-no-leaked-render

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -11,7 +11,7 @@ module.exports = {
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],
         'react/display-name': 'error',
-        'react/jsx-no-leaked-render': 'error',
+        'react/jsx-no-leaked-render': ['error', { validStrategies: ['coerce'] }],
         'react/jsx-props-no-spreading': 'off',
         'react/destructuring-assignment': 'off',
         'react/sort-comp': 'off',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config@2.3.1-canary.30.7696195233.0
  # or 
  yarn add @salutejs/eslint-config@2.3.1-canary.30.7696195233.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
