### PR TITLE
feat(eslint-config): add new rule prefer-lazy-state-initialization

### DIFF
--- a/packages/eslint-config/rules/prefer-lazy-state-initialization.js
+++ b/packages/eslint-config/rules/prefer-lazy-state-initialization.js
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: null, // `problem`, `suggestion`, or `layout`
+        docs: {
+            description: 'Detects function calls in useState and suggests using lazy initialization instead.',
+            recommended: true,
+            url: 'https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state',
+        },
+        fixable: null, // Or `code` or `whitespace`
+        schema: [], // Add a schema if the rule has options
+        messages: {
+            useLazyInitialization: 'Avoid calling function inside useState. Prefer lazy initialization.',
+        },
+    },
+
+    create: (context) => {
+        let useStateCallExpression = null;
+
+        return {
+            CallExpression(node) {
+                if (node.callee.type === 'Identifier' && node.callee.name === 'useState') {
+                    useStateCallExpression = node;
+                    return;
+                }
+
+                if (useStateCallExpression) {
+                    context.report({ node, messageId: 'useLazyInitialization' });
+                }
+            },
+
+            'CallExpression:exit': function (node) {
+                if (node === useStateCallExpression) {
+                    useStateCallExpression = null;
+                }
+            },
+        };
+    },
+};

--- a/packages/eslint-config/rules/prefer-lazy-state-initialization.test.js
+++ b/packages/eslint-config/rules/prefer-lazy-state-initialization.test.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Detects function calls in useState and suggests using lazy initialization instead.
+ * @author Patrick Gillespie
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('./prefer-lazy-state-initialization'),
+    RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const message = rule.meta.messages.useLazyInitialization;
+
+const ruleTester = new RuleTester();
+ruleTester.run('prefer-lazy-state-initialization', rule, {
+    valid: [
+        // give me some code that won't trigger a warning
+        'useState()',
+        'useState("")',
+        'useState(true)',
+        'useState(false)',
+        'useState(null)',
+        'useState(undefined)',
+        'useState(1)',
+        'useState("test")',
+        'useState(value)',
+        'useState(object.value)',
+        'useState(1 || 2)',
+        'useState(1 || 2 || 3 < 4)',
+        'useState(1 && 2)',
+        'useState(1 < 2)',
+        'useState(1 < 2 ? 3 : 4)',
+        'useState(1 == 2 ? 3 : 4)',
+        'useState(1 === 2 ? 3 : 4)',
+    ],
+
+    invalid: [
+        {
+            code: 'useState(1 || getValue())',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(2 < getValue())',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(getValue())',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(getValue(1, 2, 3))',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(a ? b : c())',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(a() ? b : c)',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(a ? (b ? b1() : b2) : c)',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(a() && b)',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(a && b())',
+            errors: [{ message, type: 'CallExpression' }],
+        },
+        {
+            code: 'useState(a() && b())',
+            errors: [
+                { message, type: 'CallExpression' },
+                { message, type: 'CallExpression' },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
This adds new rule - prefer-lazy-state-initialization. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config@2.8.0-canary.35.8188957528.0
  # or 
  yarn add @salutejs/eslint-config@2.8.0-canary.35.8188957528.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
