### PR TITLE
fix(eslint-config): fixes for no-modifying-ref

### DIFF
--- a/packages/eslint-config/rules/helpers.js
+++ b/packages/eslint-config/rules/helpers.js
@@ -9,6 +9,7 @@
  */
 
 function getFunctionName(node) {
+    if (!node) return;
     if (node.type === 'FunctionDeclaration' || (node.type === 'FunctionExpression' && node.id)) {
         // function useHook() {}
         // const whatever = function useHook() {};

--- a/packages/eslint-config/rules/no-modifying-ref-on-render.js
+++ b/packages/eslint-config/rules/no-modifying-ref-on-render.js
@@ -63,7 +63,7 @@ module.exports = {
                     isInUseEffect = true;
                 }
 
-                if (!refModifyingFunctions.includes(name) && nestingLevel === 0) {
+                if (refModifyingFunctions.includes(name) && nestingLevel === 0 && currentComponent) {
                     reportError(context, node);
                 }
             },
@@ -93,9 +93,12 @@ module.exports = {
                 if (node === currentComponent) {
                     currentComponent = null;
                     currentComponentRefNames = [];
+                    nestingLevel = 0;
                 } else {
-                    nestingLevel--;
-                    functionNestingStack.pop();
+                    if (currentComponent) {
+                        nestingLevel--;
+                        functionNestingStack.pop();
+                    }
                 }
             },
 
@@ -105,7 +108,7 @@ module.exports = {
                     node.property.name === 'current' && // this is for ref.current
                     !isInUseEffect
                 ) {
-                    if (nestingLevel == 0) {
+                    if (nestingLevel == 0 && currentComponent) {
                         reportError(context, node);
                         //  Determining the function that alter the ref and store its name
                     } else {


### PR DESCRIPTION
This fixed false positive cases outside components and in components when other functions presented in the same file
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config@2.9.3-canary.41.8821694558.0
  # or 
  yarn add @salutejs/eslint-config@2.9.3-canary.41.8821694558.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
