### PR TITLE
added support for eslint module

### DIFF
--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -1,0 +1,78 @@
+import prettierConfig from "@salutejs/prettier-config";
+
+export default {
+    extends: [
+        '@salutejs/eslint-config-base',
+        'plugin:react/recommended',
+        'plugin:react-hooks/recommended',
+        'plugin:react-perf/recommended',
+        'plugin:jsx-a11y/recommended',
+        'plugin:salute-rules/all',
+        'plugin:prettier/recommended',
+    ],
+    rules: {
+        'react/prop-types': 'off',
+        'react/static-property-placement': 'off',
+        'react/state-in-constructor': 'off',
+        'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
+        'react/jsx-one-expression-per-line': 'off',
+        'react/jsx-indent': ['error', 4],
+        'react/jsx-indent-props': ['error', 4],
+        'react/display-name': 'error',
+        'react/jsx-no-leaked-render': 'off',
+        'react/jsx-props-no-spreading': 'off',
+        'react/destructuring-assignment': 'off',
+        'react/sort-comp': 'off',
+        'react/no-array-index-key': 'off',
+        'react/require-default-props': 'off',
+        'react/function-component-definition': 'off',
+        'react/jsx-no-useless-fragment': 'off',
+        'react/no-unstable-nested-components': 'error',
+
+        'jsx-a11y/no-static-element-interactions': 'off',
+        'jsx-a11y/click-events-have-key-events': 'off',
+        'jsx-a11y/no-noninteractive-tabindex': 'off',
+
+        'no-restricted-imports': [
+            'error',
+            {
+                patterns: [
+                    '@salutejs/plasma-ui/*',
+                    '@salutejs/plasma-tokens/*',
+                    '@salutejs/plasma-icons/*',
+                    '@salutejs/plasma-web/*',
+                    '@salutejs/plasma-b2c/*',
+                ],
+            },
+        ],
+
+        'default-param-last': 'warn',
+
+        '@typescript-eslint/member-ordering': [
+            'warn',
+            {
+                default: {
+                    optionalityOrder: 'required-first',
+                },
+            },
+        ],
+        'prettier/prettier': ['error', prettierConfig],
+    },
+    overrides: [
+        {
+            files: ['*.tsx?'],
+            env: {
+                browser: true,
+            },
+            globals: {
+                window: true,
+                document: true,
+            },
+        },
+    ],
+    settings: {
+        react: {
+            version: '18.3.1',
+        },
+    },
+};

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,6 +9,10 @@
   },
   "author": "Salute Frontend Team <salute.developers@gmail.com>",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./9": "./index.mjs"
+  },
   "dependencies": {
     "@salutejs/eslint-config-base": "*",
     "eslint-plugin-salute-rules": "*"


### PR DESCRIPTION
Added a index.mjs file for ESLint module support

to use this new configuration, you should use:     ```@saultejs/eslint-config/9```


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/eslint-config@2.9.5-canary.46.12437664507.0
  npm install @salutejs/eslint-config-base@1.2.1-canary.46.12437664507.0
  npm install eslint-plugin-salute-rules@1.0.1-canary.46.12437664507.0
  npm install @salutejs/prettier-config@0.4.1-canary.46.12437664507.0
  npm install @salutejs/stylelint-config@0.8.1-canary.46.12437664507.0
  # or 
  yarn add @salutejs/eslint-config@2.9.5-canary.46.12437664507.0
  yarn add @salutejs/eslint-config-base@1.2.1-canary.46.12437664507.0
  yarn add eslint-plugin-salute-rules@1.0.1-canary.46.12437664507.0
  yarn add @salutejs/prettier-config@0.4.1-canary.46.12437664507.0
  yarn add @salutejs/stylelint-config@0.8.1-canary.46.12437664507.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
